### PR TITLE
fix: revise the prompt text in 'Next steps'

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -258,7 +258,7 @@ export async function create({
 
   const nextSteps = [
     `cd ${targetDir}`,
-    `${pkgManager} i`,
+    `${pkgManager} install`,
     `${pkgManager} run dev`,
   ];
 


### PR DESCRIPTION
When the user uses yarn, display `yarn i` is incorrect because yarn does not support the `i` command, so it should be changed to the `install` command that all package managers support.