### PR TITLE
feat: allow bypass update version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,14 @@ A shared package for create-rspack, create-rsbuild, create-rspress and create-rs
 npm add create-rstack -D
 ```
 
-## Example
+## Examples
 
-See: [create-rsbuild](https://github.com/web-infra-dev/rsbuild/tree/main/packages/create-rsbuild).
+| Project | Link                                                                                         |
+| ------- | -------------------------------------------------------------------------------------------- |
+| Rsbuild | [create-rsbuild](https://github.com/web-infra-dev/rsbuild/tree/main/packages/create-rsbuild) |
+| Rslib   | [create-rslib](https://github.com/web-infra-dev/rslib/tree/main/packages/create-rslib)       |
 
 ![image](https://github.com/user-attachments/assets/2dda3501-720c-4151-bd3e-5e038dca9e68)
-
 
 ## License
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,8 +315,8 @@ export function mergePackageJson(targetPackage: string, extraPackage: string) {
  * Copy files from one folder to another.
  * @param from Source folder
  * @param to Destination folder
- * @param version Version to update in package.json
- * @param packageName Name to update in package.json
+ * @param version - Optional. The version to update in the package.json. If not provided, version will not be updated.
+ * @param name - Optional. The name to update in the package.json. If not provided, name will not be updated.
  * @param isMergePackageJson Merge package.json files
  * @param skipFiles Files to skip
  */
@@ -330,7 +330,7 @@ export function copyFolder({
 }: {
   from: string;
   to: string;
-  version: string;
+  version?: string;
   packageName?: string;
   isMergePackageJson?: boolean;
   skipFiles?: string[];
@@ -383,17 +383,25 @@ const isStableVersion = (version: string) => {
   );
 };
 
+/**
+ * Updates the package.json file at the specified path with the provided version and name.
+ *
+ * @param pkgJsonPath - The file path to the package.json file.
+ * @param version - Optional. The version to update in the package.json. If not provided, version will not be updated.
+ * @param name - Optional. The name to update in the package.json. If not provided, name will not be updated.
+ */
 const updatePackageJson = (
   pkgJsonPath: string,
-  version: string,
+  version?: string,
   name?: string,
 ) => {
   let content = fs.readFileSync(pkgJsonPath, 'utf-8');
 
-  // Lock the version if it is not stable
-  const targetVersion = isStableVersion(version) ? `^${version}` : version;
-
-  content = content.replace(/workspace:\*/g, targetVersion);
+  if (typeof version === 'string') {
+    // Lock the version if it is not stable
+    const targetVersion = isStableVersion(version) ? `^${version}` : version;
+    content = content.replace(/workspace:\*/g, targetVersion);
+  }
 
   const pkg = JSON.parse(content);
 


### PR DESCRIPTION
In create-rslib, it will call `copyFolder` for multiple times. So allowing bypass updating package.json version in the intermediate steps and leave the final update to the end step.

Previously, it would emit `^^0.0.15` if you tried to pass `workspace:*` into `version`.

And release a new version please 😇.

![release-hamsters](https://media1.tenor.com/m/VOnZIZyPQmIAAAAC/release-hamsters.gif)
