### PR TITLE
feat: automatically set the `biome` version in its outputted config file

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": true
   },

--- a/template-biome/biome.json
+++ b/template-biome/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.8.0/schema.json",
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "organizeImports": {
     "enabled": true
   },

--- a/template-biome/biome.json
+++ b/template-biome/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/{version}/schema.json",
   "organizeImports": {
     "enabled": true
   },


### PR DESCRIPTION
Automatically set the `biome` version in its outputted config file, let it always use the **version-matched** json schema.