### PR TITLE
fix: vue+ts+setup create wrong eslint error

### DIFF
--- a/template-eslint/vue-ts/eslint.config.mjs
+++ b/template-eslint/vue-ts/eslint.config.mjs
@@ -2,11 +2,13 @@ import js from '@eslint/js';
 import vue from 'eslint-plugin-vue';
 import globals from 'globals';
 import ts from 'typescript-eslint';
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript';
 
 export default [
   { languageOptions: { globals: globals.browser } },
   js.configs.recommended,
   ...ts.configs.recommended,
   ...vue.configs['flat/essential'],
+  ...defineConfigWithVueTs(vueTsConfigs.recommended),
   { ignores: ['dist/'] },
 ];

--- a/template-eslint/vue-ts/package.json
+++ b/template-eslint/vue-ts/package.json
@@ -7,6 +7,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
+    "@vue/eslint-config-typescript": "^14.5.0",
     "eslint": "^9.23.0",
     "eslint-plugin-vue": "^10.0.0",
     "globals": "^16.0.0",


### PR DESCRIPTION
https://github.com/web-infra-dev/rsbuild/issues/4962
Template of vue3 +ts will bring a wrong eslint error, which is described in the issue.
Here is the reproduction project: https://github.com/[holyfata-reproduction/rsbuild-issue4962-reproduction](https://github.com/holyfata-reproduction/rsbuild-issue4962-reproduction)
Import vue official ts plugin can resolev the problem.