### PR TITLE
feat: skip tools selection when tools is empty string

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,10 @@ async function getTools({ tools, dir, template }: Argv) {
   if (dir && template) {
     return [];
   }
+  // skip tools selection when tools is empty string
+  if (tools === '') {
+    return [];
+  }
 
   return checkCancel<string[]>(
     await multiselect({


### PR DESCRIPTION
use `--tools ''` to skip tools selection