### PR TITLE
fix(deps): bin Biome to 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     ]
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0",
+    "@biomejs/biome": "2.0.0",
     "@clack/prompts": "^0.11.0",
     "@microsoft/api-extractor": "^7.52.8",
     "@rslib/core": "0.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: ^2.0.0
+        specifier: 2.0.0
         version: 2.0.0
       '@clack/prompts':
         specifier: ^0.11.0

--- a/template-biome/package.json
+++ b/template-biome/package.json
@@ -7,6 +7,6 @@
     "format": "biome format --write"
   },
   "devDependencies": {
-    "@biomejs/biome": "^2.0.0"
+    "@biomejs/biome": "2.0.0"
   }
 }


### PR DESCRIPTION
- Pin biome version to fix the schema warning:

<img width="1229" alt="Screenshot 2025-06-21 at 19 24 07" src="https://github.com/user-attachments/assets/2df2074e-ba2f-4aaf-af94-5f20353e54b0" />

- Biome >= 2.0.1 still have some bugs, such as:
  - https://github.com/biomejs/biome/issues/6448
  - https://github.com/biomejs/biome/issues/6435

![image](https://github.com/user-attachments/assets/0384a65b-3587-450c-b411-ff680b291254)
