### PR TITLE
fix: should run `updatePackageJson` after merge

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -407,8 +407,8 @@ export function copyFolder({
         mergePackageJson(targetPackage, srcFile);
       } else {
         fs.copyFileSync(srcFile, distFile);
-        updatePackageJson(distFile, version, packageName);
       }
+      updatePackageJson(distFile, version, packageName);
     } else {
       fs.copyFileSync(srcFile, distFile);
     }


### PR DESCRIPTION
Fix the error in https://github.com/lynx-family/lynx-stack/actions/runs/16264086737/job/45917190154?pr=1274

We need to update the version of eslint template:
<img width="921" height="349" alt="image" src="https://github.com/user-attachments/assets/de3e76be-7fe1-4258-98d4-fd92e5e308c7" />
