### PR TITLE
fix(eslint): update react refresh config to use recommended

### DIFF
--- a/template-eslint/react-js/eslint.config.mjs
+++ b/template-eslint/react-js/eslint.config.mjs
@@ -11,7 +11,7 @@ export default defineConfig([
     extends: [
       js.configs.recommended,
       reactHooks.configs['recommended-latest'],
-      reactRefresh.configs.vite,
+      reactRefresh.configs.recommended,
     ],
     languageOptions: {
       ecmaVersion: 2020,

--- a/template-eslint/react-ts/eslint.config.mjs
+++ b/template-eslint/react-ts/eslint.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig([
       js.configs.recommended,
       tseslint.configs.recommended,
       reactHooks.configs['recommended-latest'],
-      reactRefresh.configs.vite,
+      reactRefresh.configs.recommended,
     ],
     languageOptions: {
       ecmaVersion: 2020,


### PR DESCRIPTION
The react refresh configuration was changed from vite-specific to the recommended one.